### PR TITLE
Porting to Ruby 1.9.2

### DIFF
--- a/lib/fattr.rb
+++ b/lib/fattr.rb
@@ -72,7 +72,7 @@ module Fattr
 
         initialize = (
           if inheritable
-            lambda do
+            lambda do |*args|
               parents = ancestors[1..-1]
               catch(:value) do
                 parents.each do |parent|
@@ -82,7 +82,7 @@ module Fattr
               end
             end
           else
-            block || lambda{ default }
+            block || lambda{ |*args| default }
           end
         )
 


### PR DESCRIPTION
I fixed 2 lines on lib/fattr.rb so it works with ruby 1.9.2 and keeps compatible with ruby 1.8.7 and 1.8.6.
Basically, it changes the arity of lambdas so it doesn't raise 
"wrong number of arguments (1 for 0) (ArgumentError)"
